### PR TITLE
Add DevTools Author

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,3 +38,7 @@ _Awesome tooling and resources in the Chrome DevTools ecosystem_
 * [Clockwork](https://chrome.google.com/webstore/detail/clockwork/dmggabnehkmmfmdffgajcflpdjlnoemp?hl=en)  View PHP application profiling data.
 * [Emulated Device Lab](https://chrome.google.com/webstore/detail/emulated-device-lab/oaonfodocibcdobdeelbbfggjombamff) - Experiment with multiple devices being emulated at the same time.
 * [RailsPanel](https://chrome.google.com/webstore/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg?hl=en-US) - View Ruby on Rails application profiling data.
+
+### Appearance
+
+* [DevTools Author](https://chrome.google.com/webstore/detail/devtools-author/egfhcfdfnajldliefpdoaojgahefjhhi) - A selection of author settings for Chrome Developer Tools.


### PR DESCRIPTION
Added **Appearance** as a _category_ inside of Extensions and added [Devtools Author](https://chrome.google.com/webstore/detail/devtools-author/egfhcfdfnajldliefpdoaojgahefjhhi).

DevTools Author provides a small set of options to enhance and customize the Chrome Devtools.