### PR TITLE
Add Zero Dark Matrix to extensions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,3 +51,4 @@
 
 ### UX
 * [DevTools Author](https://chrome.google.com/webstore/detail/devtools-author/egfhcfdfnajldliefpdoaojgahefjhhi) - A selection of author settings for Chrome Developer Tools.
+* [Zero Dark Matrix](https://chrome.google.com/webstore/detail/devtools-theme-zero-dark/bomhdjeadceaggdgfoefmpeafkjhegbo) - Dark theme for Chrome Developer Tools.


### PR DESCRIPTION
Adds the [Zero Dark Matrix](https://chrome.google.com/webstore/detail/devtools-theme-zero-dark/bomhdjeadceaggdgfoefmpeafkjhegbo) extension to the UX category. This is a popular dark theme for DevTools.