### PR TITLE
Removed 'Zero Dark Matrix' and added 'devtool'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,3 +59,4 @@
 
 ### UX
 * [DevTools Author](https://chrome.google.com/webstore/detail/devtools-author/egfhcfdfnajldliefpdoaojgahefjhhi) - A selection of author settings for Chrome Developer Tools.
+* [Zero Dark Matrix](https://chrome.google.com/webstore/detail/devtools-theme-zero-dark/bomhdjeadceaggdgfoefmpeafkjhegbo) - Dark theme for Chrome Developer Tools.

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@
 * [DevTools Snippets](https://github.com/bahmutov/code-snippets) - Collection of DevTools snippets.
 
 ### Node.js + DevTools
+* [devtool](https://github.com/Jam3/devtool) - Runs Node.js programs inside Chrome DevTools (using Electron).
 * [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface) - The recommended Node.js API for the protocol. There are also [TypeScript-friendly alternatives](https://github.com/DickvdBrink/chrome-debug-protocol).
 * [chrome-devtools-frontend](https://www.npmjs.com/package/chrome-devtools-frontend) - Mirror of the frontend shipping in Chrome.
 * [chrome-timeline-model](https://www.npmjs.com/package/devtools-timeline-model) - Uses frontend as lib to process profiling data.
@@ -58,4 +59,3 @@
 
 ### UX
 * [DevTools Author](https://chrome.google.com/webstore/detail/devtools-author/egfhcfdfnajldliefpdoaojgahefjhhi) - A selection of author settings for Chrome Developer Tools.
-* [Zero Dark Matrix](https://chrome.google.com/webstore/detail/devtools-theme-zero-dark/bomhdjeadceaggdgfoefmpeafkjhegbo) - Dark theme for Chrome Developer Tools.


### PR DESCRIPTION
1 - Added 'devtool' since it's a great way to debug nodejs with Developer tools

2 - Removed 'Zero Dark Matrix' because Developer tools now has a dark theme setting so there's no more need to install 'Zero Dark Matrix' theme (maybe we should replace it with a link to some tutorial on how to 'Allow custom UI themes' with the 'Developer Tools experiments')