### PR TITLE
DevTools Remote URL update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 ### DevTools as an IDE
 - [Chrome DevTools App](https://github.com/auchenberg/chrome-devtools-app) - Standalone app which can inspect various targets.
-- [DevTools Remote](https://devtoolsremote.com) - Remotely debug someone else's browser.
+- [DevTools Remote](https://github.com/auchenberg/devtools-remote) - Remotely debug someone else's browser.
 - [DevTools Snippets](https://github.com/bahmutov/code-snippets) - Collection of snippets.
 
 ### Node.js + DevTools


### PR DESCRIPTION
devtoolsremote.com wasn't renewed ( https://twitter.com/auchenberg/status/846214957783932928 ).