### PR TITLE
Add BaristaLabs/chrome-dev-tools to the list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@
 - Go: [cdp](https://github.com/mafredri/cdp) - A Golang library for the protocol
 - Go: [gcd](https://github.com/wirepair/gcd) - A different client library in Go
 - Go: [godet](https://github.com/raff/godet) - Also different, also Go.
-- C#/dotnet: [chrome-dev-tools](https://github.com/BaristaLabs/chrome-dev-tools) - Protocol wrapper generator that can be customized by editing handlebars templates.
+- C#/dotnet: [chrome-dev-tools](https://github.com/BaristaLabs/chrome-dev-tools) - Protocol wrapper generator that can be customized by editing handlebars templates. Includes .Net Core template.
 
 #### Developing with the protocol 
 - [chrome-remote-interface Wiki](https://github.com/cyrus-and/chrome-remote-interface/wiki) - Many useful recipes

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@
 - Go: [cdp](https://github.com/mafredri/cdp) - A Golang library for the protocol
 - Go: [gcd](https://github.com/wirepair/gcd) - A different client library in Go
 - Go: [godet](https://github.com/raff/godet) - Also different, also Go.
+- C#/dotnet: [chrome-dev-tools](https://github.com/BaristaLabs/chrome-dev-tools) - Provides a library for generating protocol wrappers written in .Net Core with handlebars templates.
 
 #### Developing with the protocol 
 - [chrome-remote-interface Wiki](https://github.com/cyrus-and/chrome-remote-interface/wiki) - Many useful recipes

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@
 - Go: [cdp](https://github.com/mafredri/cdp) - A Golang library for the protocol
 - Go: [gcd](https://github.com/wirepair/gcd) - A different client library in Go
 - Go: [godet](https://github.com/raff/godet) - Also different, also Go.
-- C#/dotnet: [chrome-dev-tools](https://github.com/BaristaLabs/chrome-dev-tools) - Provides a library for generating protocol wrappers written in .Net Core with handlebars templates.
+- C#/dotnet: [chrome-dev-tools](https://github.com/BaristaLabs/chrome-dev-tools) - Protocol wrapper generator that can be customized by editing handlebars templates.
 
 #### Developing with the protocol 
 - [chrome-remote-interface Wiki](https://github.com/cyrus-and/chrome-remote-interface/wiki) - Many useful recipes


### PR DESCRIPTION
Added https://github.com/BaristaLabs/chrome-dev-tools to the list of driver libraries.

The description is a bit longer to indicate that BaristaLabs/chrome-dev-tools is in effect a protocol wrapper factory that uses handlebars templates to customize the output. It includes a pre-built template that targets .Net Core, but templates could be created that targets other languages or differing development approaches.