### PR TITLE
Add DevTools Backend

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@
 - [DevTools Protocol API Docs](https://chromedevtools.github.io/devtools-protocol/) - Easy browsable UI for exploring the protocol's domains, methods and events
 - [ChromeDevTools/devtools-protocol](https://github.com/chromedevtools/devtools-protocol) - Issue tracker for protocol bugs
 - [Remote Debug Gateway](https://github.com/RemoteDebug/remotedebug-gateway) - Allows you to connect a client to multiple browsers at once.
+- [DevTools Backend](https://github.com/christian-bromann/devtools-backend) - Standalone implementation of the Chrome DevTools backend to debug arbitrary web environments. 
 - [RemoteDebug](https://github.com/RemoteDebug) - Initiative to normalize debugging protocols across today's browsers.
 - [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/) - The official Selenium/WebDriver implementation for Chrome is implemented on top of the DevTools Protocol.
 


### PR DESCRIPTION
I build a Node.JS implementation of the Chrome Backend to run DevTools in arbitrary web environments. In my specific case I implemented a debugging platform for HbbTV apps on Smart TVs. It is a similar approach to the [Weinre](https://people.apache.org/~pmuellr/weinre/docs/latest/) project but I wanted to stay closer to the protocol. There is a WebDriver domain in the instrumentation script which can be used to run automated tests on instrumented targets. I haven't published the driver yet but will do soon. Here some examples:

- Debugging HbbTV apps on a Smart TV using Chrome DevTools
   https://twitter.com/bromann/status/839943193160527872
- Running WebDriver tests using that driver on a Selenium Grid
   https://twitter.com/bromann/status/890199053467885578

Hope it can be an addition to this awesome list 😉 