### PR TITLE
Add pychrome

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@
 - Java: [cdp4j](https://github.com/webfolderio/cdp4j) - Java library for CDP
 - Python: [chromote](https://github.com/iiSeymour/chromote) - Simple wrapper to drive Google Chrome from Python
 - Python: [PyChromeDevTools](https://github.com/marty90/PyChromeDevTools) - Python wrapper for Google Chrome Dev Protocol
+- Python: [pychrome](https://github.com/fate0/pychrome) - A Python Package for the Google Chrome Dev Protocol
 - Go: [chromedp](https://github.com/knq/chromedp) - High level actions and tasks for driving browsers via the Chrome Debugging Protocol
 - Go: [cdp](https://github.com/mafredri/cdp) - A Golang library for the protocol
 - Go: [gcd](https://github.com/wirepair/gcd) - A different client library in Go


### PR DESCRIPTION
A Python Package for the Google Chrome Dev Protocol

why I make another Python packages for Google Chrome Dev Protocol
* `chromote` can not use Chrome Dev Protocol directly for now
* `PyChromeDevTools` can not control multiple tabs for now