### PR TITLE
Add link to j2v8-debugger

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,7 @@
 
 ### Android
 - [Facebook Stetho](https://github.com/facebook/stetho) - Native Android debugging with Chrome DevTools.
+- [j2v8-debugger](https://github.com/AlexTrotsenko/j2v8-debugger) - Debugging JavaScript running in [J2V8](https://github.com/eclipsesource/J2V8) with Chrome DevTools.
 
 ### ClojureScript
 - [Dirac](https://github.com/binaryage/dirac) - Debugging of ClojsureScript.


### PR DESCRIPTION
It allows debugging JS running in J2V8 (V8 on Android) using Chrome DevTools.

This link could be helpful for current users of [J2V8](https://github.com/eclipsesource/J2V8) since no build-in debugger is present in the J2V8 itself.
