### PR TITLE
Add Tracium to the dev list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@
 - [headless-devtools](https://github.com/cowchimp/headless-devtools) - Perform various DevTools actions from code (e.g. get CSS Coverage, JS Heap snapshot). Uses Puppeteer + frontend as lib.
 - [crconsole](https://github.com/sidorares/crconsole) - Terminal based chrome console and debugger.
 - [sloth](https://github.com/denar90/sloth) - Chrome extension allows to enable and save CPU and network throttling for selected tabs.
+- [tracium](https://github.com/aslushnikov/tracium) - A blessed Chrome Trace parser. Tracium is the Google Lighthouse tracing parser extracted into a stand-alone library.
 
 ## Browser Adapters
 - [Remote Debug Firefox adapter](https://github.com/RemoteDebug/remotedebug-firefox-adapter) - Translates Firefox's devtools protocol to the CDP.


### PR DESCRIPTION
We at Sauce use Tracium to get the list of main thread tasks from a trace log.