### PR TITLE
Added link in developing with dev tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@
 - [DevTools Backend](https://github.com/christian-bromann/devtools-backend) - Standalone implementation of the Chrome DevTools backend to debug arbitrary web environments.
 - [RemoteDebug](https://github.com/RemoteDebug) - Initiative to normalize debugging protocols across today's browsers.
 - [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/) - The official Selenium/WebDriver implementation for Chrome is implemented on top of the DevTools Protocol.
-- [CloudBrowser](https://free.cloudbrowser.xyz) - Allows you to have a 30-minute 'remote browser' session powered by chrome devtools protocol.
+- [BrowserGap CE](https://github.com/dosycorp/browsergap.ce) - A remote browser product, open sourced.
 
 ### Automation
 - [Puppeteer](https://github.com/GoogleChrome/puppeteer/) - Node.js offering a high-level API to control headless Chrome over the DevTools Protocol.

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@
 - [DevTools Backend](https://github.com/christian-bromann/devtools-backend) - Standalone implementation of the Chrome DevTools backend to debug arbitrary web environments.
 - [RemoteDebug](https://github.com/RemoteDebug) - Initiative to normalize debugging protocols across today's browsers.
 - [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/) - The official Selenium/WebDriver implementation for Chrome is implemented on top of the DevTools Protocol.
-- [BrowserGap CE](https://github.com/dosycorp/browsergap.ce) - A remote browser product, open sourced.
+- [BrowserGap Community Edition](https://github.com/dosycorp/browsergap.ce) - A remote browser product, open sourced. Makes heavy use of the raw, tip-of-tree Chrome DevTools protocol.
 
 ### Automation
 - [Puppeteer](https://github.com/GoogleChrome/puppeteer/) - Node.js offering a high-level API to control headless Chrome over the DevTools Protocol.

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@
 - [DevTools Backend](https://github.com/christian-bromann/devtools-backend) - Standalone implementation of the Chrome DevTools backend to debug arbitrary web environments.
 - [RemoteDebug](https://github.com/RemoteDebug) - Initiative to normalize debugging protocols across today's browsers.
 - [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/) - The official Selenium/WebDriver implementation for Chrome is implemented on top of the DevTools Protocol.
+- [CloudBrowser](https://free.cloudbrowser.xyz) - Allows you to have a 30-minute 'remote browser' session powered by chrome devtools protocol.
 
 ### Automation
 - [Puppeteer](https://github.com/GoogleChrome/puppeteer/) - Node.js offering a high-level API to control headless Chrome over the DevTools Protocol.


### PR DESCRIPTION
I don't think you'll merge this PR because it looks like it's just promoting a commercial product.

I made a 'remote browser isolation' platform and share this free demo of it here. 

I heavily rely on Chrome devtools for this task so want to give back to the community by showing what's possible.

As I'm unwilling to release the source (because the full product is money-making) I'm quite sure you'll be unable to include it here.