### PR TITLE
Fix awesome-lint tests

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup node
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
The repository age is computed based on the oldest fetched commit.
The default depth 1 forces awesome-lint to use the age of the latest commit as the age of the repo (which is obviously invalid).

See:
https://github.com/sindresorhus/awesome-lint/issues/105

And the doc specifically mentions `fetch-depth: 0` here:
https://github.com/sindresorhus/awesome-lint#github-actions