### PR TITLE
Remove a link to mare as it doesn't exist now

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,9 +115,6 @@
 #### ClojureScript
 - [Dirac](https://github.com/binaryage/dirac) - Debugging of ClojsureScript.
 
-#### Lua
-- [Mare](https://github.com/muzuiget/mare) - Lua debugging with Chrome DevTools.
-
 #### iOS
 - [PonyDebugger](https://github.com/square/PonyDebugger) - Remote network and data debugging iOS apps with Chrome DevTools.
 


### PR DESCRIPTION
I'm not sure why, but https://github.com/muzuiget/mare doesn't exist(or private?) now.