### PR TITLE
Add ruby/debug library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,9 @@
 - [thetool](https://github.com/sfninja/thetool) - CPU, memory, coverage, type profiling with Node.
 - [chrome-devtools-frontend](https://www.npmjs.com/package/chrome-devtools-frontend) - Mirror of the frontend that ships in Chrome.
 
+#### Ruby
+- [ruby/debug](https://github.com/ruby/debug) - Debugging functionality for Ruby
+
 ---
 
 ## DevTools Extensions


### PR DESCRIPTION
This PR adds [ruby/debug](https://github.com/ruby/debug). It is used Chrome DevTools Frontend.

BTW, when I implemented this feature, this lists were really helpful. Thank you!