### PR TITLE
Add Puppeteer IDE extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,3 +163,6 @@
 ### Performance
 - [sloth](https://github.com/denar90/sloth) - Chrome extension allows to enable and save CPU and network throttling for selected tabs.
 - [TracerBench](https://github.com/TracerBench/tracerbench) - TracerBench is a controlled performance benchmarking tool for web applications, providing clear, actionable and usable insights into performance deltas.
+
+### Automation
+- [Puppeteer IDE](https://github.com/gajananpp/puppeteer-ide-extension) - Standalone Puppeteer playground in browser's developer tools.


### PR DESCRIPTION
[puppeteer-ide-extension](https://github.com/gajananpp/puppeteer-ide-extension) is a standalone chrome extension to write and execute puppeteer scripts from browser's developer tools. It executes the script on inspected tab.

![Extension Demo GIF](https://raw.githubusercontent.com/gajananpp/puppeteer-ide-extension/main/assets/pptr-ide-extension.webp)