### PR TITLE
Update broken link for Chromelens

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@
 ## DevTools Extensions
 
 ### Accessibility (A11y)
-- [Chromelens](http://chromelens.xyz) - See how your web app will look to people with different types of vision and the path users will travel when tabbing through your page.
+- [Chromelens](https://chrome.google.com/webstore/detail/chromelens/idikgljglpfilbhaboonnpnnincjhjkd) - See how your web app will look to people with different types of vision and the path users will travel when tabbing through your page.
 
 ### Workflow
 - [Clockwork](https://chrome.google.com/webstore/detail/clockwork/dmggabnehkmmfmdffgajcflpdjlnoemp?hl=en) - View PHP application profiling data.


### PR DESCRIPTION
Apparently chromelens.xyz URL is not related anymore, so I've updated the link to be the extension's page.