### PR TITLE
Add k6-browser link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,6 +156,7 @@
 
 ### Automation
 - [Puppeteer IDE](https://github.com/gajananpp/puppeteer-ide-extension) - Standalone Puppeteer playground in browser's developer tools.
+- [k6 browser](https://github.com/grafana/xk6-browser) - Browser automation and end-to-end web testing tool that interacts with browsers and collects frontend performance metrics.
 
 ## Alumni
 Old projects, likely not maintained any longer… But still cool.


### PR DESCRIPTION
k6-browser adds support for browser automation and end-to-end web testing via the Chrome Devtools Protocol (CDP). It uses CDP to drive browsers for testing websites.

More information about the project:
* https://grafana.com/docs/k6/latest/javascript-api/k6-browser/
* https://grafana.com/docs/k6/latest/using-k6-browser/
* https://grafana.com/docs/k6/latest/using-k6-browser/running-browser-tests/
* https://grafana.com/docs/k6/latest/using-k6-browser/metrics/
* https://grafana.com/blog/2023/01/08/how-to-add-browser-level-apis-for-web-performance-metrics/