### PR TITLE
update actions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 22
 
       - run: yarn install
       - run: yarn test


### PR DESCRIPTION
Use the latest actions that are depended on. Bump node version up to 22 which will be the next LTS version in about a month.

This fixes the failures for CI executions.