### PR TITLE
Add Chrome Secret Menus to Learning section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@
 - [Can I DevTools?](https://www.canidev.tools/) - Various workflows, documented. Also a weekly tips & tricks [newsletter](https://canidevtools.substack.com/).
 - [Web cheatcodes](https://codepo8.github.io/web-cheatcodes/) - Browser developer tools for non-developers.
 - [Dear Console](https://codepo8.github.io/dearconsole) - A collection of snippets to use in the browser console.
+- [Chrome Secret Menus](https://github.com/sparkyrider/chrome-secret-menus) - Comprehensive guide to internal pages and diagnostic tools in Chrome.
 
 ---
 


### PR DESCRIPTION
Adding comprehensive guide to Chrome internal pages (chrome://) for diagnostics, debugging, etc. Updated frequently :) 