### PR TITLE
Add Lumen to CDP libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@
 - TypeScript/Node.js: [chrome-debugging-client](https://github.com/TracerBench/chrome-debugging-client)
 - TypeScript/Node.js: [noice-json-rpc](https://www.npmjs.com/package/noice-json-rpc) - A proxy-based implementation to expose the CDP as its API.
 - TypeScript/Node.js: [Taiko](https://github.com/getgauge/taiko/)
+- TypeScript/Node.js: [Lumen](https://github.com/omxyz/lumen) - Vision-first browser agent with self-healing deterministic replay over CDP.
 - Rust: [Rust Headless Chrome](https://github.com/atroche/rust-headless-chrome/)
 - Java: [chrome-devtools-java-client](https://github.com/kklisura/chrome-devtools-java-client)
 - Java: [jvppeteer](https://github.com/fanyong920/jvppeteer)  - Headless Chrome For Java 


### PR DESCRIPTION
Add [Lumen](https://github.com/omxyz/lumen) — TypeScript/Node.js vision-first browser agent with self-healing deterministic replay over CDP.