### PR TITLE
Add cdpilot - Zero-dependency CDP automation CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@
 - Python: [chromewhip](https://github.com/chuckus/chromewhip) - drop-in replacement for the `splash` service
 - Python: [pyppeteer](https://github.com/pyppeteer/pyppeteer) - Puppeteer port
 - Python: [ChromeController](https://github.com/fake-name/ChromeController) - high-level browser mgmt
+- Python/Node.js: [cdpilot](https://github.com/mehmetnadir/cdpilot) - Zero-dependency browser automation CLI with 40+ commands and built-in MCP server for AI agents. Uses CDP over HTTP/WebSocket.
 - Go: [chromedp](https://github.com/chromedp/chromedp) - High-level actions and tasks for driving browsers
 - Go: [cdp](https://github.com/mafredri/cdp)
 - Go: [gcd](https://github.com/wirepair/gcd)


### PR DESCRIPTION
## What is cdpilot?

[cdpilot](https://github.com/mehmetnadir/cdpilot) is a zero-dependency browser automation CLI that communicates directly with Chromium-based browsers over the Chrome DevTools Protocol via HTTP and WebSocket.

### Key features:
- **Pure CDP** - Uses HTTP + WebSocket directly (urllib + asyncio), no wrapper libraries
- **40+ commands** - Navigation, DOM interaction, debugging, network interception, device emulation, screenshots, PDF export, accessibility audits, and more
- **Built-in MCP server** - JSON-RPC over stdin/stdout for AI agent integration
- **Zero dependencies** - Python stdlib only, no pip packages needed
- **Node.js entry point** - `npx cdpilot` finds Python3 and browser automatically
- **50KB total size**

### Installation:
```
npx cdpilot launch
```

**npm:** https://www.npmjs.com/package/cdpilot
**GitHub:** https://github.com/mehmetnadir/cdpilot

Added to **Libraries for driving the protocol** as a Python/Node.js CDP client with CLI and MCP server capabilities.