### PR TITLE
Add dig2browser - Rust stealth browser automation library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@
 - TypeScript/Node.js: [Taiko](https://github.com/getgauge/taiko/)
 - TypeScript/Node.js: [Lumen](https://github.com/omxyz/lumen) - Vision-first browser agent with self-healing deterministic replay over CDP.
 - Rust: [Rust Headless Chrome](https://github.com/atroche/rust-headless-chrome/)
+- Rust: [dig2browser](https://github.com/ZENG3LD/dig2browser) - Stealth browser automation with custom CDP + WebDriver + BiDi backends. Chrome, Edge, Firefox.
 - Java: [chrome-devtools-java-client](https://github.com/kklisura/chrome-devtools-java-client)
 - Java: [jvppeteer](https://github.com/fanyong920/jvppeteer)  - Headless Chrome For Java 
 - Python: [PyCDP](https://github.com/hyperiongray/python-chrome-devtools-protocol) - Pure-Python, sans-IO wrappers. See also the [Trio CDP driver](https://github.com/hyperiongray/trio-chrome-devtools-protocol)


### PR DESCRIPTION
Adds dig2browser, a Rust library for stealth browser automation with custom CDP, WebDriver, and BiDi backends. Supports Chrome, Edge, and Firefox with zero external browser-automation dependencies.