### PR TITLE
Add ClawBench to Applications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,6 +133,9 @@
 
 ### Web Archivers and Indexers
 - [dn](https://github.com/dosyago/dn) - Archive and index pages you browse for offline viewing and search, implemented using the `Fetch` domain's interceptions, and works with any Chromium-based browser.
+
+### Agent Evaluation
+- [ClawBench](https://github.com/reacher-z/ClawBench) - Benchmark that runs browser agents on live production sites, using the `Fetch` domain to intercept and block only the final outbound submission so runs complete end-to-end without real-world side effects.
   
 ---
 


### PR DESCRIPTION
Adds ClawBench under Applications as an Agent Evaluation entry. ClawBench uses Chrome DevTools Protocol request interception to evaluate browser agents on 283 V1+V2 tasks across 163 live websites, recording replay, screenshots, HTTP traffic, browser actions, and agent messages, with judge-based outcome evaluation.\n\nCanonical paper: https://arxiv.org/abs/2604.08523\nRepository: https://github.com/TIGER-AI-Lab/ClawBench\nProject: https://claw-bench.com/\n\nDisclosure: submitted as a ClawBench maintainer.