### PR TITLE
Add: Browy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,7 @@
 - [TracerBench](https://github.com/TracerBench/tracerbench) - A controlled performance benchmarking tool for web applications, providing clear, actionable and usable insights into performance deltas.
 
 ### Automation
+- [Browy](https://github.com/BrowyHQ/browy) - Open-source AI agent that lives in a Chromium extension (Chrome / Edge / Brave). Drives the active tab through the DevTools Protocol from a side panel chat or a terminal-style DevTools panel CLI. Powered by your GitHub Copilot subscription.
 - [Puppeteer IDE](https://github.com/gajananpp/puppeteer-ide-extension) - Standalone Puppeteer playground in browser's developer tools.
 - [k6 browser](https://github.com/grafana/xk6-browser) - Browser automation and end-to-end web testing tool that interacts with browsers and collects frontend performance metrics.
 


### PR DESCRIPTION
Adding Browy under DevTools Extensions > Automation.

- Repo: https://github.com/BrowyHQ/browy
- Docs: https://browyhq.github.io/
- Apache-2.0

Browy is a browser AI agent that lives inside a Chromium extension. It drives the active tab through the Chrome DevTools Protocol (via chrome.debugger) for accessibility-tree snapshots, click and type by index, JavaScript evaluation, and network/console reads. Surfaces as a side panel chat and a terminal-style DevTools panel REPL.

Strong fit for this list because the entire automation loop is CDP. The DevTools Protocol is the actual interface the agent uses to read and drive pages.

Disclosure: I'm the maintainer.