### PR TITLE
Add OhMyPerf to Timeline, Tracing & Profiling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@
 
 ### Timeline, Tracing & Profiling
 - [DevTools Timeline Viewer](https://chromedevtools.github.io/timeline-viewer/) - Share URLs of your timeline recordings.
+- [OhMyPerf](https://github.com/hoainho/ohmyperf) - Real-Chromium Core Web Vitals (LCP/INP/CLS/FCP/TBT/TTFB) measurement with cross-origin OOPIF inspection (~99% coverage) via per-frame `CDPSession`, long-task → script-URL attribution, and Mann-Whitney U regression detection. Drives Chromium through Playwright + raw CDP (`Target.setAutoAttach`), and exposes an MCP server so LLM agents can `measure → propose_patch → verify_fix` end-to-end.
 
 ### Chrome Debugger integration with Editors
 - [VS Code - Debugger for Chrome](https://github.com/Microsoft/vscode-chrome-debug/) - Breakpoint debugging in VS Code.


### PR DESCRIPTION
Adds **OhMyPerf** under `DevTools tooling and ecosystem → Timeline, Tracing & Profiling` — a real-Chromium Core Web Vitals measurement tool that drives Chromium through the DevTools Protocol via Playwright + raw CDP.

## Why this list fits

OhMyPerf's value comes from **using CDP correctly**, not from being yet another performance dashboard:

- **`Target.setAutoAttach({flatten: true})`** for cross-origin OOPIF inspection. Each cross-origin iframe gets its own `CDPSession` via Playwright's `context.newCDPSession(frame)`. We hit ~99% iframe coverage and verified it against real-world embedded surfaces (mdnplay.dev, openstreetmap.org, example.org).
- **`Performance.getMetrics` + `Input.dispatchMouseEvent`** + `web-vitals/attribution` for honest LCP/INP/CLS measurement on user hardware. INP is measurable in CI because we synthesize a trusted-event interaction via CDP rather than relying on a human click.
- **`longtask` PerformanceObserver + `Network.requestWillBeSent`** joined back to script URL for long-task attribution down to the file path.
- **Mann-Whitney U** regression detection against a baseline report at α=0.05 with per-metric noise floors (avoids the flake-prone fixed-threshold pattern that plagues Lighthouse-CI gates).

## What's distinct from existing entries

The closest existing entry under Timeline/Tracing/Profiling is **DevTools Timeline Viewer** (chromedevtools.github.io/timeline-viewer/), which is read-only and viewer-focused. OhMyPerf is on the production side: it actually drives the browser, records the trace, computes CWV + diagnostics, and produces a structured report consumable by both humans and LLM agents.

Most CDP-driver entries in the list (Puppeteer, Playwright, the high-level libraries section) are *primitives* — OhMyPerf is an *application* of those primitives specifically for CWV measurement, and exposes them through an MCP server so LLM agents can call `measure → propose_patch → verify_fix` end-to-end.

## Status

- Apache-2.0
- `@ohmyperf/cli` and `@ohmyperf/mcp-server` published on npm
- 387 tests across 18 workspaces, all green
- Real-world validated against 10 production sites
- Public repo: https://github.com/hoainho/ohmyperf

Thanks for maintaining this list — the CDP ecosystem has been hard to navigate for years and this is the canonical entry point.