### PR TITLE
Add Quietbench link to Chrome DevTools Protocol section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@
 ## Chrome DevTools Protocol
 - [ChromeDevTools/devtools-protocol](https://github.com/chromedevtools/devtools-protocol) - **Canonical location of the protocol JSON**. Issue tracker for protocol bugs. TypeScript types.
 - [DevTools Protocol API Docs](https://chromedevtools.github.io/devtools-protocol/) - Easy browsable UI for exploring the protocol's domains, methods and events.
+- [Quietbench](https://quietbench.dev) - Free browser-based developer utilities...
 
 ### Developing with the protocol
 - [chrome-remote-interface Wiki](https://github.com/cyrus-and/chrome-remote-interface/wiki) - Many useful recipes.


### PR DESCRIPTION
Added link to Quietbench, a browser-based developer utility.