### PR TITLE
Add Wirepeek to DevTools Extensions > Workflow

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@
 - [Insight](https://github.com/3Dparallax/insight/) - A WebGL debugging toolkit which enables more productive WebGL development and more efficient WebGL applications.
 - [BEM devtools](https://github.com/escaton/bem-chrome-devtools) - Inspect BEM entities expressed in `i-bem` framework.
 - [Web Component DevTools](https://chromewebstore.google.com/detail/web-component-devtools/gdniinfdlmmmjpnhgnkmfpffipenjljo) - Inspect, modify and observe Web Components on page.
+- [Wirepeek](https://chromewebstore.google.com/detail/wirepeek/ojoojkjcpibfddgcljlfbjobkcpcbejn) - Inspect and decode live WebSocket frames: Socket.IO/Engine.IO, MessagePack, CBOR, gzip and JSON nested in string fields.
 
 ### Themes
 - [Material UI Theme](https://chromewebstore.google.com/detail/material-devtools-theme-c/jmefikbdhgocdjeejjnnepgnfkkbpgjo) - Provides various Material Design inspired themes.


### PR DESCRIPTION
Supersedes #195 - same change, re-submitted so the commit is authored under the email my Google CLA is signed with (the first attempt used my GitHub noreply address, which the CLA bot can't match). I'll close #195.

Adds Wirepeek to DevTools Extensions > Workflow, at the bottom of the section per contributing.md.

Why it belongs here: it's a DevTools panel for traffic the Network tab shows but doesn't decode. WebSocket frames arrive on the wire as `42["event",{...}]` - Engine.IO packet type 4 wrapping Socket.IO type 2 - with a bare `2` heartbeat mixed into application traffic, and binary payloads shown as an opaque blob. Wirepeek resolves the framing into event names and a JSON tree, and unwraps nested base64/gzip, MessagePack, CBOR and Thrift. It hooks WebSocket.prototype in the page's main world at document_start, so it captures the handshake and survives reloads - which the Network tab cannot when DevTools is opened after the connection.

Read-only, no account, no backend, one permission (storage). Free.

Disclosure: I'm the author. Published to the Chrome Web Store on 2 July 2026, well past the two-week guideline in contributing.md, and I use it daily on my own real-time work.