### PR TITLE
Add cdp-drive to Python CDP libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@
 - Python: [chromewhip](https://github.com/chuckus/chromewhip) - drop-in replacement for the `splash` service
 - Python: [pyppeteer](https://github.com/pyppeteer/pyppeteer) - Puppeteer port
 - Python: [ChromeController](https://github.com/fake-name/ChromeController) - high-level browser mgmt
+- Python: [cdp-drive](https://github.com/immineal/cdp-drive) - A CDP browser driver in one file. No Playwright/Selenium install required.
 - Go: [chromedp](https://github.com/chromedp/chromedp) - High-level actions and tasks for driving browsers
 - Go: [cdp](https://github.com/mafredri/cdp)
 - Go: [gcd](https://github.com/wirepair/gcd)


### PR DESCRIPTION
Adds `cdp-drive` (https://github.com/immineal/cdp-drive) to the Python section of "Libraries for driving the protocol." It's a single-file CDP driver with no Playwright/Selenium dependency — useful when you want direct protocol access without installing a full automation framework. Not a general-purpose scraping/automation library like the others in this section; it's deliberately minimal (one file, stdlib + `websockets` only). Repo created 2026-08-17, README and examples included.